### PR TITLE
Silence `mandoc -T lint` warnings

### DIFF
--- a/login_duress.8
+++ b/login_duress.8
@@ -110,16 +110,14 @@ utility:
 .Bd -literal -offset indent
 $ encrypt -b10
 .Ed
-.Pp
 .Sh FILES
 .Bl -tag -width /etc/duress -compact
 .It Pa /etc/duress
 user database with duress passwords and commands
 .El
-.Pp
 .Sh SEE ALSO
+.Xr encrypt 1 ,
 .Xr login 1 ,
 .Xr passwd 1 ,
 .Xr su 1 ,
-.Xr login.conf 5 ,
-.Xr encrypt 1
+.Xr login.conf 5


### PR DESCRIPTION
Fix a handful of minor issues in the manual page.